### PR TITLE
Tidy way to maintain extended wxcode help

### DIFF
--- a/lib/improver/cli/wxcode.py
+++ b/lib/improver/cli/wxcode.py
@@ -37,7 +37,8 @@ from improver import cli
 @cli.clizefy
 @cli.with_output
 def process(*cubes: cli.inputcube,
-            wxtree='high_resolution'):
+            wxtree='high_resolution',
+            extended_help=None):
     """ Processes cube for Weather symbols.
 
     Args:
@@ -48,6 +49,10 @@ def process(*cubes: cli.inputcube,
             Weather Code tree.
             Choices are high_resolution or global.
             Default is 'high_resolution'.
+        extended_help (str):
+            Get extended help about the necessary inputs for a weather symbol
+            tree as it is currently configured. Choices are high_resolution or
+            global.
 
     Returns:
         iris.cube.Cube:
@@ -56,6 +61,11 @@ def process(*cubes: cli.inputcube,
     """
     from iris.cube import CubeList
     from improver.wxcode.weather_symbols import WeatherSymbols
+    from improver.wxcode.wxcode_utilities import interrogate_decision_tree
+
+    if extended_help is not None:
+        print(interrogate_decision_tree(extended_help))
+        return
 
     # TODO: Consider adding detail to help output
     return WeatherSymbols(wxtree=wxtree).process(CubeList(cubes))

--- a/lib/improver/tests/wxcode/wxcode/test_wxcode_utilities.py
+++ b/lib/improver/tests/wxcode/wxcode/test_wxcode_utilities.py
@@ -52,7 +52,8 @@ from improver.utilities.save import save_netcdf
 from improver.wxcode.wxcode_utilities import (WX_DICT,
                                               add_wxcode_metadata,
                                               expand_nested_lists,
-                                              update_daynight)
+                                              update_daynight,
+                                              interrogate_decision_tree)
 
 
 def datetime_to_numdateval(year=2018, month=9, day=12, hour=5, minutes=43):
@@ -500,6 +501,21 @@ class Test_update_daynight(IrisTest):
         result = update_daynight(cube)
         self.assertArrayEqual(result.data, expected_result)
 
+
+class Test_interrogate_decision_tree(IrisTest):
+    """Test the function for generating extended help."""
+
+    def test_return_type(self):
+        """Test that the function returns a string."""
+        result = interrogate_decision_tree('global')
+        self.assertIsInstance(result, str)
+
+    def test_raises_exception(self):
+        """Test the function raises an exception for an unknown weather symbol
+        tree name."""
+        msg = "Unknown decision tree name provided."
+        with self.assertRaisesRegex(ValueError, msg):
+            interrogate_decision_tree('kittens')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds extended help as an option to the CLI. Code to generate the extended help detailing the required inputs has been moved to wxcode utilities. This approach avoids the need to import the module in the CLI unless requested, keeps the CLI tidy, and maintains this useful information.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)